### PR TITLE
get rid of old 89->256 LBM

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -379,24 +379,4 @@ minetest.register_lbm({
 	end
 })
 
-minetest.register_lbm({
-	name = "unifiedbricks:recolor_bricks",
-	label = "Convert 89-color bricks to use UD extended palette",
-	run_at_every_load = false,
-	nodenames = {
-		"unifiedbricks:clayblock",
-		"unifiedbricks:brickblock",
-		"unifiedbricks:brickblock_multicolor_dark",
-		"unifiedbricks:brickblock_multicolor_medium",
-		"unifiedbricks:brickblock_multicolor_light",
-	},
-	action = function(pos, node)
-		local meta = minetest.get_meta(pos)
-		if meta:get_string("palette") ~= "ext" then
-			minetest.swap_node(pos, { name = node.name, param2 = unifieddyes.convert_classic_palette[node.param2] })
-			meta:set_string("palette", "ext")
-		end
-	end
-})
-
 print("[UnifiedBricks] Loaded!")


### PR DESCRIPTION
It's obsolete, and can't run anyway, because UD doesn't support the old 89-color palette anymore except in split mode.  Worst that might happen without this LBM is some wrong-colored nodes out in the least-visited parts of a world.